### PR TITLE
Add complex type; slight schema refactor

### DIFF
--- a/fdsn-station-schema.json
+++ b/fdsn-station-schema.json
@@ -33,6 +33,14 @@
         }
     },
     "definitions": {
+        "fdsn-complex": {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "items": {
+                "type": "number" 
+            }
+        },
         "fdsn-date-time": {
             "type": "string",
             "format": "date-time",
@@ -90,6 +98,10 @@
                     }
                 }
             }
+        },
+        "fdsn-responseStages": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/fdsn-responseStage" }
         },
         "fdsn-responseStage": {
             "type": "object",
@@ -162,17 +174,13 @@
                             "normalizationFrequency": {
                                 "type": "number"
                             },
-                            "zero": {
+                            "zeros": {
                                 "type": "array",
-                                "items": {
-                                    "type": { "$ref": "#/definitions/fdsn-floatNoUnit" }
-                                }
+                                "items": { "$ref": "#/definitions/fdsn-complex" }
                             },
-                            "pole": {
+                            "poles": {
                                 "type": "array",
-                                "items": {
-                                    "type": { "$ref": "#/definitions/fdsn-floatNoUnit" }
-                                }
+                                "items": { "$ref": "#/definitions/fdsn-complex" }
                             }
                         }
                     }
@@ -238,7 +246,7 @@
             "additionalProperties": false,
             "properties": {
                 "inputSampleRate": {"type": "number"},
-                "factor": {"type": "number"},
+                "factor": {"type": "integer"},
                 "offset": {"type": "number"},
                 "delay": {"type": "number"},
                 "correction": {"type": "number"}
@@ -387,6 +395,10 @@
                             "type": "string",
                             "description": "Short site location description"
                         },
+                        "country": {
+                            "type": "string",
+                            "description": "Country of site location"
+                        },
                         "description": {
                             "type": "string",
                             "description": "Longer description of the site location"
@@ -495,6 +507,9 @@
                 "scaleFrequency": {
                     "type": "number",
                     "description": "Frequency in Hertz at which scale is valid"
+                },
+                "responseStages": {
+                    "$ref": "#/definitions/fdsn-responseStages"
                 },
                 "restrictedStatus": {
                     "$ref": "#/definitions/fdsn-restrictedStatus"

--- a/tools/StationXML2StationJSON.py
+++ b/tools/StationXML2StationJSON.py
@@ -14,7 +14,7 @@ class StationXML2StationJSON():
   """
 
   NAMESPACE = "{http://www.fdsn.org/xml/station/1}"
-  MODULE = None
+  MODULE = "StationXML2StationJSON"
   SCHEMA_VERSION = "1.0"
 
   def __init__(self):
@@ -89,7 +89,7 @@ class StationXML2StationJSON():
       "type": "paz",
       "inputUnits": self.findElementText(stage, ["InputUnits", "Name"]),
       "outputUnits": self.findElementText(stage, ["OutputUnits", "Name"]),
-      "transferFunctionType": self.findElementText(stage, "PzTransferFunctionType"),
+      "pzTransferFunctionType": self.findElementText(stage, "PzTransferFunctionType"),
       "normalizationFactor": self.findElementText(stage, "NormalizationFactor", float),
       "normalizationFrequency": self.findElementText(stage, "NormalizationFrequency", float),
       "zeros": map(self.extractComplex, stage.findall(self.NAMESPACE + "Zero")),
@@ -103,7 +103,11 @@ class StationXML2StationJSON():
     Returns float representation of an element
     """
 
-    return float(x.text)
+    return {
+      "value": float(x.text),
+      "plusError": 0,
+      "minError": 0
+    }
     
   
   def extractDecimation(self, decimation):
@@ -205,7 +209,7 @@ class StationXML2StationJSON():
     """
 
     stageDict = {
-      "gain": self.findElementText(stage, ["StageGain", "Value"], float),
+      "stageGain": self.findElementText(stage, ["StageGain", "Value"], float),
       "gainFrequency": self.findElementText(stage, ["StageGain", "Frequency"], float)
     }
   

--- a/tools/convert.py
+++ b/tools/convert.py
@@ -1,5 +1,7 @@
 import requests
+import os
 import json
+import jsonschema
 
 from StationXML2StationJSON import StationXML2StationJSON
 
@@ -10,11 +12,17 @@ if __name__ == "__main__":
   FDSNStationXML and StationJSON
   """
 
-  URL = "https://www.orfeus-eu.org/fdsnws/station/1/query?net=NL&sta=*&cha=HHN&level=response"
+  URL = "https://www.orfeus-eu.org/fdsnws/station/1/query?net=NL&sta=HGN&cha=BHZ&level=response"
 
   Convertor = StationXML2StationJSON()
 
   # Parse & print
   output = Convertor.convert(requests.get(URL).content)
+
+  # Validate against the schema
+  schemaPath = os.path.join(os.path.dirname(__file__), "..", "fdsn-station-schema.json");
+  with open(schemaPath, "rt") as filehandle:
+    schema = json.load(filehandle)
+  jsonschema.validate(output, schema)
 
   print json.dumps(output, indent=4)


### PR DESCRIPTION
Here are some proposed changes:

* Added fdsn-complex for property of the form: `[real, imag]`.
* Added `country` attribute to `site` property.
* Added `responseStages` attribute to channel. This will contain an array of `responseStage` elements for each consecutive response stage.
* Changed `decimationFactor` from general `number` to `integer`.
* Made `pole` & `zero` to plural as attribute names.

* Refactored some of the conversion script to be more in line with the current schema. Added validation of result from the conversion.